### PR TITLE
Fix for OpenVPN protocol error

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -145,7 +145,7 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 
 	# required for use in iptables
 	if [[ "${VPN_PROTOCOL}" == "tcp-client" ]]; then
-		export VPN_PROTOCOL="tcp"
+		export VPN_PROTOCOL_IPTABLES="tcp"
 	fi
 
 	VPN_DEVICE_TYPE=$(cat "${VPN_CONFIG}" | grep -P -o -m 1 '(?<=^dev\s)[^\r\n\d]+' | sed -e 's~^[ \t]*~~;s~[ \t]*$~~')

--- a/run/root/iptable.sh
+++ b/run/root/iptable.sh
@@ -88,7 +88,7 @@ iptables -A INPUT -i "${VPN_DEVICE_TYPE}" -j ACCEPT
 iptables -A INPUT -s "${docker_network_cidr}" -d "${docker_network_cidr}" -j ACCEPT
 
 # accept input to vpn gateway
-iptables -A INPUT -i eth0 -p $VPN_PROTOCOL --sport $VPN_PORT -j ACCEPT
+iptables -A INPUT -i eth0 -p $VPN_PROTOCOL_IPTABLES --sport $VPN_PORT -j ACCEPT
 
 # accept input to sabnzbd webui port 8080
 iptables -A INPUT -i eth0 -p tcp --dport 8080 -j ACCEPT
@@ -155,7 +155,7 @@ iptables -A OUTPUT -o "${VPN_DEVICE_TYPE}" -j ACCEPT
 iptables -A OUTPUT -s "${docker_network_cidr}" -d "${docker_network_cidr}" -j ACCEPT
 
 # accept output from vpn gateway
-iptables -A OUTPUT -o eth0 -p $VPN_PROTOCOL --dport $VPN_PORT -j ACCEPT
+iptables -A OUTPUT -o eth0 -p $VPN_PROTOCOL_IPTABLES --dport $VPN_PORT -j ACCEPT
 
 # if iptable mangle is available (kernel module) then use mark
 if [[ $iptable_mangle_exit_code == 0 ]]; then


### PR DESCRIPTION
After updating to the latest version of your container I was getting the following error on startup:

_Options error: --proto tcp is ambiguous in this context. Please specify --proto tcp-server or --proto tcp-client_

This is an OpenVPN error.

I think I've tracked down the issue to the use of the VPN_PROTOCOL variable in **both** the OpenVPN config and the IPTABLES setup. By creating a separate variable, VPN_PROTOCOL_IPTABLES, I believe the issue is fixed.